### PR TITLE
Fix failures and exit non-0 when there is a failure

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,11 +19,15 @@ class NotarizeCliCommand extends Command {
       flags.username,
       flags.password,
     ).catch(() => undefined);
+
     console.log('done');
+
     if (!requestUuid) {
       console.error('Error: could not upload file for notarization');
     } else {
       let requestStatus = 'in progress';
+
+      console.log(`Request UUID is ${requestUuid}`);
 
       // Sometimes Apple receives the upload and issues a UUID, but is not ready to return request status right away
       // Allow up to 5 retries on error before giving up and calling this an actual failure

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ class NotarizeCliCommand extends Command {
 
     if (!requestUuid) {
       console.error('Error: could not upload file for notarization');
+      this.exit(1);
     } else {
       let requestStatus = 'in progress';
 
@@ -63,6 +64,7 @@ class NotarizeCliCommand extends Command {
         : console.error('Error: could not get notarization info');
       if (requestStatus !== 'success') {
         console.error(`Error: could not notarize file`);
+        this.exit(1);
       }
     }
   }


### PR DESCRIPTION
- Apple periodically will accept a file for upload and return a UUID, but when calling `getRequestStatus` the first time or two, will respond as if it has no idea the UUID exists. This adds retry logic to work around this, which I have confirmed to work in our own project
- Adds exit code 1 for failure cases, so that if running this in CI and notarization fails, the step is marked as failed properly. CI can choose whether or not to ignore or continue at that point (Resolves #1)